### PR TITLE
Added nolink Option For Creditsstate.hx

### DIFF
--- a/source/CreditsState.hx
+++ b/source/CreditsState.hx
@@ -34,6 +34,7 @@ class CreditsState extends MusicBeatState
 	var intendedColor:Int;
 	var colorTween:FlxTween;
 	var descBox:AttachedSprite;
+        var noLink:Bool;
 
 	var offsetThing:Float = -75;
 
@@ -205,9 +206,21 @@ class CreditsState extends MusicBeatState
 				}
 			}
 
+						if(creditsStuff[curSelected][3] == 'nolink') {
+
+				noLink = true;
+			}else{
+				noLink = false;
+			}
+			if(noLink) {
 			if(controls.ACCEPT) {
+				FlxG.sound.play(Paths.sound('cancelMenu'));
+			} 
+			}else {
+				if(controls.ACCEPT) {
 				CoolUtil.browserLoad(creditsStuff[curSelected][3]);
 			}
+		}
 			if (controls.BACK)
 			{
 				if(colorTween != null) {


### PR DESCRIPTION
- ### What does it do:
 it makes cancelMenu.ogg sound play when you click accept on someone's credits with 'nolink' instead of a normal link
- ### How to use:
Just put nolink where you put the link in your credits
- ### Example:
```hx
['Cherry', 'C', 'wooooo', 'nolink', '3405bb'],